### PR TITLE
Release-Hotfix: 카테고리별 상품 조회 API, 위시리스트 전체 조회 API 비즈니스 로직 수정

### DIFF
--- a/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/application/ProductCategoryListService.java
+++ b/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/application/ProductCategoryListService.java
@@ -9,15 +9,14 @@ public interface ProductCategoryListService {
     void addProductByCategories(ProductCategoryListRequestDto productCategoryListRequestDto);
 
     CursorPage<ProductCategoryListResponseDto> getProductCategoryListByCategories(
-        String mainCategoryCode, String secondaryCategoryCode, String tertiaryCategoryCode,
-        String quaternaryCategoryCode,
-        Long lastId, Integer pageSize, Integer pageNo);
-
-    void updateProductCategoryList(ProductCategoryListRequestDto productCategoryListRequestDto);
+        String categoryCode, Long lastId, Integer pageSize, Integer pageNo);
 
     CursorPage<ProductCategoryListResponseDto> getProductCodesByOptions(
         String mainCategoryCode, String secondaryCategoryCode,
         String tertiaryCategoryCode, String quaternaryCategoryCode,
         Long lastId, Integer pageSize, Integer pageNo,
         Long sizeId, Long colorId, Long etcId);
+
+    void updateProductCategoryList(ProductCategoryListRequestDto productCategoryListRequestDto);
+
 }

--- a/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/application/ProductCategoryListServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/application/ProductCategoryListServiceImpl.java
@@ -34,13 +34,10 @@ public class ProductCategoryListServiceImpl implements ProductCategoryListServic
     @Transactional(readOnly = true)
     @Override
     public CursorPage<ProductCategoryListResponseDto> getProductCategoryListByCategories(
-        String mainCategoryCode, String secondaryCategoryCode,
-        String tertiaryCategoryCode, String quaternaryCategoryCode,
-        Long lastId, Integer pageSize, Integer pageNo) {
+        String categoryCode, Long lastId, Integer pageSize, Integer pageNo) {
 
         CursorPage<String> cursorPage = productCategoryListRepositoryCustom.getProductCategoryListByCategories(
-            mainCategoryCode, secondaryCategoryCode, tertiaryCategoryCode, quaternaryCategoryCode,
-            lastId, pageSize, pageNo);
+            categoryCode, lastId, pageSize, pageNo);
 
         return CursorPage.toCursorPage(cursorPage,
             cursorPage.getContent().stream().map(ProductCategoryListResponseDto::toDto).toList());

--- a/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/infrastructure/ProductCategoryListRepositoryCustom.java
+++ b/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/infrastructure/ProductCategoryListRepositoryCustom.java
@@ -9,10 +9,7 @@ import org.springframework.stereotype.Repository;
 public interface ProductCategoryListRepositoryCustom {
 
     CursorPage<String> getProductCategoryListByCategories(
-            String mainCategoryCode, String secondaryCategoryCode,
-            String tertiaryCategoryCode, String quaternaryCategoryCode,
-            Long lastId, Integer pageSize, Integer pageNo
-    );
+            String categoryCode, Long lastId, Integer pageSize, Integer pageNo);
 
     CursorPage<String> getProductCodesByOptions(
         String mainCategoryCode, String secondaryCategoryCode,

--- a/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/infrastructure/ProductCategoryListRepositoryImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/infrastructure/ProductCategoryListRepositoryImpl.java
@@ -26,24 +26,22 @@ public class ProductCategoryListRepositoryImpl implements ProductCategoryListRep
 
     @Override
     public CursorPage<String> getProductCategoryListByCategories(
-        String mainCategoryCode, String secondaryCategoryCode,
-        String tertiaryCategoryCode, String quaternaryCategoryCode,
-        Long lastId, Integer pageSize, Integer pageNo) {
+        String categoryCode, Long lastId, Integer pageSize, Integer pageNo) {
 
         BooleanBuilder builder = new BooleanBuilder();
 
         // 카테고리별 필터 적용
-        Optional.ofNullable(mainCategoryCode)
-            .ifPresent(code -> builder.and(productCategoryList.mainCategoryCode.eq(code)));
+        Optional.ofNullable(categoryCode)
+            .ifPresent(code -> builder.or(productCategoryList.mainCategoryCode.eq(code)));
 
-        Optional.ofNullable(secondaryCategoryCode)
-            .ifPresent(code -> builder.and(productCategoryList.secondaryCategoryCode.eq(code)));
+        Optional.ofNullable(categoryCode)
+            .ifPresent(code -> builder.or(productCategoryList.secondaryCategoryCode.eq(code)));
 
-        Optional.ofNullable(tertiaryCategoryCode)
-            .ifPresent(code -> builder.and(productCategoryList.tertiaryCategoryCode.eq(code)));
+        Optional.ofNullable(categoryCode)
+            .ifPresent(code -> builder.or(productCategoryList.tertiaryCategoryCode.eq(code)));
 
-        Optional.ofNullable(quaternaryCategoryCode)
-            .ifPresent(code -> builder.and(productCategoryList.quaternaryCategoryCode.eq(code)));
+        Optional.ofNullable(categoryCode)
+            .ifPresent(code -> builder.or(productCategoryList.quaternaryCategoryCode.eq(code)));
 
         // 판매 중인가
         builder.and(productCategoryList.isOnSale.eq(true));

--- a/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/presentation/ProductCategoryListController.java
+++ b/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/presentation/ProductCategoryListController.java
@@ -34,47 +34,44 @@ public class ProductCategoryListController {
     }
 
     @Operation(summary = "Product-Category-List 조회 API", description = "카테고리별 상품 조회")
-    @GetMapping
+    @GetMapping("/{categoryCode}")
     public BaseResponse<CursorPage<GetProductCategoryListResponseVo>> getProductCategoryList(
-            @RequestParam(value = "mainCategoryCode", required = false) String mainCategoryCode,
-            @RequestParam(value = "secondaryCategoryCode", required = false) String secondaryCategoryCode,
-            @RequestParam(value = "tertiaryCategoryCode", required = false) String tertiaryCategoryCode,
-            @RequestParam(value = "quaternaryCategoryCode", required = false) String quaternaryCategoryCode,
+            @PathVariable String categoryCode,
             @RequestParam(value = "lastId", required = false) Long lastId,
             @RequestParam(value = "pageSize", required = false) Integer pageSize,
             @RequestParam(value = "pageNo", required = false) Integer pageNo
     ) {
         CursorPage<ProductCategoryListResponseDto> cursorPage = productCategoryListService.
-            getProductCategoryListByCategories(mainCategoryCode, secondaryCategoryCode,
-                tertiaryCategoryCode, quaternaryCategoryCode, lastId, pageSize, pageNo);
+            getProductCategoryListByCategories(categoryCode, lastId, pageSize, pageNo);
 
         return new BaseResponse<>(CursorPage.toCursorPage(cursorPage,
             cursorPage.getContent().stream().map(ProductCategoryListResponseDto::toVo).toList()));
     }
 
-    @Operation(summary = "Option에 따른 Product-Category-List 조회 API", description = "Get Product-Category-List By Option")
-    @GetMapping("/options")
-    public BaseResponse<CursorPage<GetProductCategoryListResponseVo>> getProductCodesByOptions(
-        @RequestParam(value = "mainCategoryCode", required = false) String mainCategoryCode,
-        @RequestParam(value = "secondaryCategoryCode", required = false) String secondaryCategoryCode,
-        @RequestParam(value = "tertiaryCategoryCode", required = false) String tertiaryCategoryCode,
-        @RequestParam(value = "quaternaryCategoryCode", required = false) String quaternaryCategoryCode,
-        @RequestParam(value = "lastId", required = false) Long lastId,
-        @RequestParam(value = "pageSize", required = false) Integer pageSize,
-        @RequestParam(value = "pageNo", required = false) Integer pageNo,
-        @RequestParam(value = "sizeId", required = false) Long sizeId,
-        @RequestParam(value = "colorId", required = false) Long colorId,
-        @RequestParam(value = "etcId", required = false) Long etcId
-    ) {
-        CursorPage<ProductCategoryListResponseDto> cursor = productCategoryListService.getProductCodesByOptions(
-            mainCategoryCode, secondaryCategoryCode, tertiaryCategoryCode, quaternaryCategoryCode,
-            lastId, pageSize, pageNo, sizeId, colorId, etcId);
-
-        return new BaseResponse<>(
-            CursorPage.toCursorPage(cursor,
-                cursor.getContent().stream().map(ProductCategoryListResponseDto::toVo).toList())
-        );
-    }
+    // 로직 수정 필요
+//    @Operation(summary = "Option에 따른 Product-Category-List 조회 API", description = "Get Product-Category-List By Option")
+//    @GetMapping("/options")
+//    public BaseResponse<CursorPage<GetProductCategoryListResponseVo>> getProductCodesByOptions(
+//        @RequestParam(value = "mainCategoryCode", required = false) String mainCategoryCode,
+//        @RequestParam(value = "secondaryCategoryCode", required = false) String secondaryCategoryCode,
+//        @RequestParam(value = "tertiaryCategoryCode", required = false) String tertiaryCategoryCode,
+//        @RequestParam(value = "quaternaryCategoryCode", required = false) String quaternaryCategoryCode,
+//        @RequestParam(value = "lastId", required = false) Long lastId,
+//        @RequestParam(value = "pageSize", required = false) Integer pageSize,
+//        @RequestParam(value = "pageNo", required = false) Integer pageNo,
+//        @RequestParam(value = "sizeId", required = false) Long sizeId,
+//        @RequestParam(value = "colorId", required = false) Long colorId,
+//        @RequestParam(value = "etcId", required = false) Long etcId
+//    ) {
+//        CursorPage<ProductCategoryListResponseDto> cursor = productCategoryListService.getProductCodesByOptions(
+//            mainCategoryCode, secondaryCategoryCode, tertiaryCategoryCode, quaternaryCategoryCode,
+//            lastId, pageSize, pageNo, sizeId, colorId, etcId);
+//
+//        return new BaseResponse<>(
+//            CursorPage.toCursorPage(cursor,
+//                cursor.getContent().stream().map(ProductCategoryListResponseDto::toVo).toList())
+//        );
+//    }
 
     @Operation(summary = "Product-Category-List 판매 상태 수정 API", description =
         "productCode & categoryCodes 조건 모두 같은 경우 찾아서 Update")

--- a/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/presentation/ProductCategoryListController.java
+++ b/src/main/java/com/jokim/sivillage/api/bridge/productcategorylist/presentation/ProductCategoryListController.java
@@ -39,8 +39,8 @@ public class ProductCategoryListController {
             @PathVariable String categoryCode,
             @RequestParam(value = "lastId", required = false) Long lastId,
             @RequestParam(value = "pageSize", required = false) Integer pageSize,
-            @RequestParam(value = "pageNo", required = false) Integer pageNo
-    ) {
+            @RequestParam(value = "pageNo", required = false) Integer pageNo) {
+
         CursorPage<ProductCategoryListResponseDto> cursorPage = productCategoryListService.
             getProductCategoryListByCategories(categoryCode, lastId, pageSize, pageNo);
 
@@ -48,7 +48,7 @@ public class ProductCategoryListController {
             cursorPage.getContent().stream().map(ProductCategoryListResponseDto::toVo).toList()));
     }
 
-    // 로직 수정 필요
+    // TODO: 로직 수정 필요
 //    @Operation(summary = "Option에 따른 Product-Category-List 조회 API", description = "Get Product-Category-List By Option")
 //    @GetMapping("/options")
 //    public BaseResponse<CursorPage<GetProductCategoryListResponseVo>> getProductCodesByOptions(

--- a/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/application/EventWishlistService.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/application/EventWishlistService.java
@@ -9,7 +9,7 @@ public interface EventWishlistService {
 
     void addEventWishlist(EventWishlistRequestDto eventWishlistRequestDto);
 
-    List<EventWishlistResponseDto> getAllEventWishlists(String accessToken);
+    List<EventWishlistResponseDto> getAllEventWishlists(String accessToken, Integer recentMonths);
     EventWishlistResponseDto getEventWishlistState(String accessToken, String eventCode);
 
     void deleteEventWishlist(EventWishlistRequestDto eventWishlistRequestDto);

--- a/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/application/EventWishlistServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/application/EventWishlistServiceImpl.java
@@ -4,6 +4,7 @@ import com.jokim.sivillage.api.wishlist.eventwishlist.domain.EventWishlist;
 import com.jokim.sivillage.api.wishlist.eventwishlist.dto.EventWishlistRequestDto;
 import com.jokim.sivillage.api.wishlist.eventwishlist.dto.EventWishlistResponseDto;
 import com.jokim.sivillage.api.wishlist.eventwishlist.infrastructure.EventWishlistRepository;
+import com.jokim.sivillage.api.wishlist.eventwishlist.infrastructure.EventWishlistRepositoryCustom;
 import com.jokim.sivillage.common.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -17,6 +18,7 @@ import java.util.List;
 public class EventWishlistServiceImpl implements EventWishlistService {
 
     private final EventWishlistRepository eventWishlistRepository;
+    private final EventWishlistRepositoryCustom eventWishlistRepositoryCustom;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -32,10 +34,10 @@ public class EventWishlistServiceImpl implements EventWishlistService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<EventWishlistResponseDto> getAllEventWishlists(String accessToken) {
+    public List<EventWishlistResponseDto> getAllEventWishlists(String accessToken, Integer recentMonths) {
 
-        return eventWishlistRepository.findByUuidAndIsCheckedOrderByUpdatedAtDesc(
-                jwtTokenProvider.validateAndGetUserUuid(accessToken), true)
+        return eventWishlistRepositoryCustom.getAllEventWishlists(
+                jwtTokenProvider.validateAndGetUserUuid(accessToken), recentMonths)
                 .stream().map(EventWishlistResponseDto::toDto).toList();
     }
 

--- a/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/infrastructure/EventWishlistRepository.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/infrastructure/EventWishlistRepository.java
@@ -3,13 +3,10 @@ package com.jokim.sivillage.api.wishlist.eventwishlist.infrastructure;
 import com.jokim.sivillage.api.wishlist.eventwishlist.domain.EventWishlist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface EventWishlistRepository extends JpaRepository<EventWishlist, Long> {
 
     Optional<EventWishlist> findByUuidAndEventCode(String uuid, String eventCode);
-
-    List<EventWishlist> findByUuidAndIsCheckedOrderByUpdatedAtDesc(String uuid, Boolean isChecked);
 
 }

--- a/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/infrastructure/EventWishlistRepositoryCustom.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/infrastructure/EventWishlistRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jokim.sivillage.api.wishlist.eventwishlist.infrastructure;
+
+import com.jokim.sivillage.api.wishlist.eventwishlist.domain.EventWishlist;
+import java.util.List;
+
+public interface EventWishlistRepositoryCustom {
+
+    List<EventWishlist> getAllEventWishlists(String uuid, Integer recentMonths);
+
+}

--- a/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/infrastructure/EventWishlistRepositoryImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/infrastructure/EventWishlistRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.jokim.sivillage.api.wishlist.eventwishlist.infrastructure;
+
+import com.jokim.sivillage.api.wishlist.eventwishlist.domain.EventWishlist;
+import com.jokim.sivillage.api.wishlist.eventwishlist.domain.QEventWishlist;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class EventWishlistRepositoryImpl implements EventWishlistRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QEventWishlist eventWishlist = QEventWishlist.eventWishlist;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<EventWishlist> getAllEventWishlists(String uuid, Integer recentMonths) {
+
+        LocalDateTime currentDate = LocalDateTime.now();
+        BooleanBuilder builder = new BooleanBuilder();
+
+        Optional.ofNullable(uuid)
+            .ifPresent(id -> builder.and(eventWishlist.uuid.eq(id)));
+
+        // 최근 몇 달 필터링
+        Optional.ofNullable(recentMonths).ifPresent(
+            months -> builder.and(eventWishlist.updatedAt.gt(currentDate.minusMonths(months))));
+
+        builder.and(eventWishlist.isChecked.eq(true));
+
+        return jpaQueryFactory.selectFrom(eventWishlist)
+            .where(builder)
+            .orderBy(eventWishlist.updatedAt.desc())
+            .fetch();
+
+    }
+
+}

--- a/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/presentation/EventWishlistController.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/eventwishlist/presentation/EventWishlistController.java
@@ -35,12 +35,15 @@ public class EventWishlistController {
         return new BaseResponse<>();
     }
 
-    @Operation(summary = "이벤트 Wishlist 전체 조회 API")
+    @Operation(summary = "이벤트 Wishlist 전체 조회 API", description =
+        "recentMonths로 최근 N 개월 동안 찜한 것들만 필터링")
     @GetMapping
     public BaseResponse<List<GetAllEventWishlistResponseVo>> getAllEventWishlists(
-            @RequestHeader("Authorization") String authorizationHeader) {
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(value = "recentMonths", required = false) Integer recentMonths) {
 
-        return new BaseResponse<>(eventWishlistService.getAllEventWishlists(extractToken(authorizationHeader))
+        return new BaseResponse<>(eventWishlistService.getAllEventWishlists(
+            extractToken(authorizationHeader), recentMonths)
                 .stream().map(EventWishlistResponseDto::toVoForEventCode).toList());
     }
 

--- a/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/application/ProductWishlistService.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/application/ProductWishlistService.java
@@ -9,7 +9,7 @@ public interface ProductWishlistService {
 
     void addProductWishlist(ProductWishlistRequestDto productWishlistRequestDto);
 
-    List<ProductWishlistResponseDto> getAllProductWishlists(String accessToken);
+    List<ProductWishlistResponseDto> getAllProductWishlists(String accessToken, Integer recentMonths);
     ProductWishlistResponseDto getProductWishlistState(String accessToken, String productCode);
 
     void deleteProductWishlist(ProductWishlistRequestDto productWishlistRequestDto);

--- a/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/application/ProductWishlistServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/application/ProductWishlistServiceImpl.java
@@ -4,6 +4,7 @@ import com.jokim.sivillage.api.wishlist.productwishlist.domain.ProductWishlist;
 import com.jokim.sivillage.api.wishlist.productwishlist.dto.ProductWishlistRequestDto;
 import com.jokim.sivillage.api.wishlist.productwishlist.dto.ProductWishlistResponseDto;
 import com.jokim.sivillage.api.wishlist.productwishlist.infrastructure.ProductWishlistRepository;
+import com.jokim.sivillage.api.wishlist.productwishlist.infrastructure.ProductWishlistRepositoryCustom;
 import com.jokim.sivillage.common.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.List;
 public class ProductWishlistServiceImpl implements ProductWishlistService {
 
     private final ProductWishlistRepository productWishlistRepository;
+    private final ProductWishlistRepositoryCustom productWishlistRepositoryCustom;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -31,10 +33,10 @@ public class ProductWishlistServiceImpl implements ProductWishlistService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<ProductWishlistResponseDto> getAllProductWishlists(String accessToken) {
+    public List<ProductWishlistResponseDto> getAllProductWishlists(String accessToken, Integer recentMonths) {
 
-        return productWishlistRepository.findByUuidAndIsCheckedOrderByUpdatedAtDesc(
-                jwtTokenProvider.validateAndGetUserUuid(accessToken), true)
+        return productWishlistRepositoryCustom.getAllProductWishlists(
+                jwtTokenProvider.validateAndGetUserUuid(accessToken), recentMonths)
                 .stream().map(ProductWishlistResponseDto::toDto).toList();
     }
 

--- a/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/infrastructure/ProductWishlistRepository.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/infrastructure/ProductWishlistRepository.java
@@ -10,6 +10,4 @@ public interface ProductWishlistRepository extends JpaRepository<ProductWishlist
 
     Optional<ProductWishlist> findByUuidAndProductCode(String uuid, String productCode);
 
-    List<ProductWishlist> findByUuidAndIsCheckedOrderByUpdatedAtDesc(String uuid, Boolean isChecked);
-
 }

--- a/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/infrastructure/ProductWishlistRepositoryCustom.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/infrastructure/ProductWishlistRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jokim.sivillage.api.wishlist.productwishlist.infrastructure;
+
+import com.jokim.sivillage.api.wishlist.productwishlist.domain.ProductWishlist;
+import java.util.List;
+
+public interface ProductWishlistRepositoryCustom {
+
+    List<ProductWishlist> getAllProductWishlists(String uuid, Integer recentMonths);
+
+}

--- a/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/infrastructure/ProductWishlistRepositoryImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/infrastructure/ProductWishlistRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.jokim.sivillage.api.wishlist.productwishlist.infrastructure;
+
+import com.jokim.sivillage.api.wishlist.productwishlist.domain.ProductWishlist;
+import com.jokim.sivillage.api.wishlist.productwishlist.domain.QProductWishlist;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductWishlistRepositoryImpl implements ProductWishlistRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QProductWishlist productWishlist = QProductWishlist.productWishlist;
+
+    @Override
+    public List<ProductWishlist> getAllProductWishlists(String uuid, Integer recentMonths) {
+
+        LocalDateTime currentDate = LocalDateTime.now();
+        BooleanBuilder builder = new BooleanBuilder();
+
+        Optional.ofNullable(uuid)
+            .ifPresent(id -> builder.and(productWishlist.uuid.eq(id)));
+
+        // 최근 몇 달 필터링
+        Optional.ofNullable(recentMonths).ifPresent(
+            months -> builder.and(productWishlist.updatedAt.gt(currentDate.minusMonths(months))));
+
+        // 체크 상태인가
+        builder.and(productWishlist.isChecked.eq(true));
+
+        return jpaQueryFactory.selectFrom(productWishlist)
+            .where(builder)
+            .orderBy(productWishlist.updatedAt.desc())
+            .fetch();
+
+    }
+}

--- a/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/presentation/ProductWishlistController.java
+++ b/src/main/java/com/jokim/sivillage/api/wishlist/productwishlist/presentation/ProductWishlistController.java
@@ -35,13 +35,16 @@ public class ProductWishlistController {
         return new BaseResponse<>();
     }
 
-    @Operation(summary = "상품 Wishlist 전체 조회 API")
+    @Operation(summary = "상품 Wishlist 전체 조회 API", description =
+        "recentMonths로 최근 N 개월 동안 찜한 것들만 필터링")
     @GetMapping
     public BaseResponse<List<GetAllProductWishlistResponseVo>> getAllProductWishlists(
-            @RequestHeader("Authorization") String authorizationHeader) {
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(value = "recentMonths", required = false) Integer recentMonths) {
 
-        return new BaseResponse<>(productWishlistService.getAllProductWishlists(extractToken(authorizationHeader))
-                .stream().map(ProductWishlistResponseDto::toVoForProductCode).toList());
+        return new BaseResponse<>(productWishlistService.getAllProductWishlists(
+            extractToken(authorizationHeader), recentMonths).stream()
+            .map(ProductWishlistResponseDto::toVoForProductCode).toList());
     }
 
     @Operation(summary = "상품 Wishlist 상태 조회 API")


### PR DESCRIPTION
## 📣 Release-Hotfix: 카테고리별 상품 조회 API, 위시리스트 전체 조회 API 비즈니스 로직 수정
### 📅 2024.09.25

### 🌵 Branch
( hotfix ) → ( release )

### 📢 Description
- **카테고리별 상품 조회 API**: categoryCode를 필수로 받고 하나만 받아도 필터링 되도록 수정
- **위시리스트 전체 조회 API**: recentMonths를 RequestParam 선택값으로 받아서 최근 몇 달 이내 위시리스트 담은 항목만 볼 수 있도록 필터링 추가 (Product-Wishlist, Event-Wishlist 수정)

### 💬 Issue Number
[ #65 ] - 카테고리별 상품 조회 API, 위시리스트 전체 조회 API 비즈니스 로직 수정

### 🛠️ Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖 Note
기존 Product-Category-List에서 제공하던 필터링 기능을 임시 주석 처리