### PR TITLE
ALB health-check Controller 구현 및 예외 처리 수정

### DIFF
--- a/src/main/java/com/jokim/sivillage/api/brand/application/BrandServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/brand/application/BrandServiceImpl.java
@@ -39,7 +39,8 @@ public class BrandServiceImpl implements BrandService {
     @Override
     public List<BrandResponseDetailDto> getAllBrands() {
 
-        return brandRepository.findAllByOrderByEnglishInitial().stream()
+        // koreanInitial == null: 페이지가 없는 brand
+        return brandRepository.findAllByKoreanNameIsNotNullOrderByEnglishInitial().stream()
                 .map(BrandResponseDetailDto::toDto).toList();
     }
 

--- a/src/main/java/com/jokim/sivillage/api/brand/application/BrandServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/brand/application/BrandServiceImpl.java
@@ -51,7 +51,7 @@ public class BrandServiceImpl implements BrandService {
             brandMediaListRepositoryCustom.getBrandLogoUrl(brandCode) : null;
 
         return BrandSummaryResponseDto.toDto(brandRepository.findByBrandCode(brandCode)
-            .orElse(new Brand()), mediaUrl);
+            .orElseThrow(() -> new BaseException(NOT_EXIST_BRAND)), mediaUrl);
     }
 
     @Transactional

--- a/src/main/java/com/jokim/sivillage/api/brand/infrastructure/BrandRepository.java
+++ b/src/main/java/com/jokim/sivillage/api/brand/infrastructure/BrandRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface BrandRepository extends JpaRepository<Brand, Long> {
 
-    List<Brand> findAllByOrderByEnglishInitial();
+    List<Brand> findAllByKoreanNameIsNotNullOrderByEnglishInitial();
 
     Optional<Brand> findByBrandCode(String brandCode);
 

--- a/src/main/java/com/jokim/sivillage/api/media/application/MeidaServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/media/application/MeidaServiceImpl.java
@@ -34,7 +34,7 @@ public class MeidaServiceImpl implements MediaService {
     @Override
     public MediaResponseDto getMedia(String mediaCode) {
         return MediaResponseDto.toDto(mediaRepository.findByMediaCode(mediaCode)
-            .orElse(new Media()));
+            .orElseThrow(() -> new BaseException(NOT_EXIST_MEDIA)));
     }
 
     @Transactional

--- a/src/main/java/com/jokim/sivillage/common/aws/StatusCheckController.java
+++ b/src/main/java/com/jokim/sivillage/common/aws/StatusCheckController.java
@@ -1,0 +1,19 @@
+package com.jokim.sivillage.common.aws;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden
+@RestController
+public class StatusCheckController {
+
+    @GetMapping("/health-check")
+    public ResponseEntity<Void> checkHealthStatus() {
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/jokim/sivillage/common/config/SecurityConfig.java
+++ b/src/main/java/com/jokim/sivillage/common/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 authorizeRequests -> authorizeRequests
                     .requestMatchers(
+                        "/health-check",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/v1/**",


### PR DESCRIPTION
## 📣 ALB health-check Controller 구현 및 예외 처리 수정
### 📅 2024.09.28

### 🌵 Branch
( feature/health-check ) → ( develop )

### 📢 Description
- 지속적으로 나타나는 **net::ERR_SSL_PROTOCOL_ERROR**
=> Load Balancer의 Target Group이 Unhealthy로 나오므로 ALB health-check Controller 구현

- Brand 전체 조회 API, Brand Summary 조회 API, Media Info 조회 API 예외 처리 추가 및 수정

### 💬 Issue Number
[ #79 ] - Brand, Media 데이터 조회 API 관련 수정
[ #78 ] - ALB health-check Controller 구현

### 🛠️ Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖 Note
- 추후에 AOP로 NoLogging 어노테이션 추가 예정
- Brand 데이터에서 korean_initial이 null인 데이터들은 Product 데이터 INSERT 할 때 brand_code 정보가 존재하지 않아서 임의로 집어넣은 값 **(실제 사이트에서도 Brand 페이지가 없는 데이터들)**