### PR TITLE
Release-Hotfix: 장바구니 페이지에서의 상품 옵션 Info 조회 API 구현

### DIFF
--- a/src/main/java/com/jokim/sivillage/api/basket/application/BasketService.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/application/BasketService.java
@@ -6,6 +6,8 @@ import com.jokim.sivillage.api.basket.dto.in.UpdateBasketRequestDto;
 import com.jokim.sivillage.api.basket.dto.out.AllBasketItemsResponseDto;
 import com.jokim.sivillage.api.basket.dto.out.BasketItemCountResponseDto;
 import com.jokim.sivillage.api.basket.dto.out.ExistsInBasketResponseDto;
+import com.jokim.sivillage.api.basket.dto.out.ProductOptionInfoResponseDto;
+
 import java.util.List;
 
 public interface BasketService {
@@ -15,8 +17,9 @@ public interface BasketService {
     List<AllBasketItemsResponseDto> getAllBasketItems(String accessToken);
     BasketItemCountResponseDto getBasketItemCount(String accessToken);
     ExistsInBasketResponseDto existsInBasket(String accessToken, String productOptionCode);
+    ProductOptionInfoResponseDto getProductOptionInfo(String productOptionCode);
 
-    void updateBasketItemCount(UpdateBasketRequestDto updateBasketRequestDto);
+    void updateBasketItemQuantity(UpdateBasketRequestDto updateBasketRequestDto);
     void updateBasketItemCheck(UpdateBasketRequestDto updateBasketRequestDto);
 
     void deleteBasketItems(List<DeleteBasketItemRequestDto> deleteBasketItemRequestDtoList);

--- a/src/main/java/com/jokim/sivillage/api/basket/application/BasketServiceImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/application/BasketServiceImpl.java
@@ -8,7 +8,10 @@ import com.jokim.sivillage.api.basket.dto.in.UpdateBasketRequestDto;
 import com.jokim.sivillage.api.basket.dto.out.AllBasketItemsResponseDto;
 import com.jokim.sivillage.api.basket.dto.out.BasketItemCountResponseDto;
 import com.jokim.sivillage.api.basket.dto.out.ExistsInBasketResponseDto;
+import com.jokim.sivillage.api.basket.dto.out.ProductOptionInfoResponseDto;
 import com.jokim.sivillage.api.basket.infrastructure.BasketRepository;
+import com.jokim.sivillage.api.basket.infrastructure.BasketRepositoryCustom;
+import com.jokim.sivillage.api.product.infrastructure.ProductOptionRepository;
 import com.jokim.sivillage.common.exception.BaseException;
 import com.jokim.sivillage.common.jwt.JwtTokenProvider;
 import com.jokim.sivillage.common.utils.CodeGenerator;
@@ -25,7 +28,10 @@ import static com.jokim.sivillage.common.entity.BaseResponseStatus.*;
 public class BasketServiceImpl implements BasketService {
 
     private final BasketRepository basketRepository;
+    private final BasketRepositoryCustom basketRepositoryCustom;
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final ProductOptionRepository productOptionRepository;
 
     private static final int MAX_CODE_TRIES = 5;
 
@@ -68,9 +74,16 @@ public class BasketServiceImpl implements BasketService {
                 .validateAndGetUserUuid(accessToken), productOptionCode, BasketState.ACTIVE));
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public ProductOptionInfoResponseDto getProductOptionInfo(String productOptionCode) {
+        return basketRepositoryCustom.getProductOptionInfo(productOptionRepository.findByProductOptionCode(
+                productOptionCode).orElseThrow(() -> new BaseException(NOT_EXIST_PRODUCT_OPTION)));
+    }
+
     @Transactional
     @Override
-    public void updateBasketItemCount(UpdateBasketRequestDto updateBasketRequestDto) {
+    public void updateBasketItemQuantity(UpdateBasketRequestDto updateBasketRequestDto) {
         if(updateBasketRequestDto.getQuantity() <= 0) throw new BaseException(INVALID_PRODUCT_QUANTITY);
 
         basketRepository.save(updateBasketRequestDto.toEntityForQuantity(

--- a/src/main/java/com/jokim/sivillage/api/basket/dto/in/UpdateBasketRequestDto.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/dto/in/UpdateBasketRequestDto.java
@@ -3,7 +3,7 @@ package com.jokim.sivillage.api.basket.dto.in;
 import com.jokim.sivillage.api.basket.domain.Basket;
 import com.jokim.sivillage.api.basket.domain.BasketState;
 import com.jokim.sivillage.api.basket.vo.in.UpdateBasketItemCheckRequestVo;
-import com.jokim.sivillage.api.basket.vo.in.UpdateBasketItemCountRequestVo;
+import com.jokim.sivillage.api.basket.vo.in.UpdateBasketItemQuantityRequestVo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,12 +16,12 @@ public class UpdateBasketRequestDto {
     private Boolean isChecked;
     private Short quantity;
 
-    public static UpdateBasketRequestDto toDto(String accessToken, UpdateBasketItemCountRequestVo updateBasketItemCountRequestVo) {
+    public static UpdateBasketRequestDto toDto(String accessToken, UpdateBasketItemQuantityRequestVo updateBasketItemQuantityRequestVo) {
 
             return UpdateBasketRequestDto.builder()
                     .accessToken(accessToken)
-                    .basketCode(updateBasketItemCountRequestVo.getBasketCode())
-                    .quantity(updateBasketItemCountRequestVo.getQuantity())
+                    .basketCode(updateBasketItemQuantityRequestVo.getBasketCode())
+                    .quantity(updateBasketItemQuantityRequestVo.getQuantity())
                     .build();
     }
 

--- a/src/main/java/com/jokim/sivillage/api/basket/dto/out/ProductOptionInfoResponseDto.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/dto/out/ProductOptionInfoResponseDto.java
@@ -1,0 +1,23 @@
+package com.jokim.sivillage.api.basket.dto.out;
+
+import com.jokim.sivillage.api.basket.vo.out.GetProductOptionInfoResponseVo;
+import lombok.Builder;
+
+@Builder
+public class ProductOptionInfoResponseDto {
+
+    private String optionInfo;
+
+    public static ProductOptionInfoResponseDto toDto(String productOptionInfo) {
+        return ProductOptionInfoResponseDto.builder()
+                .optionInfo(productOptionInfo)
+                .build();
+    }
+
+    public GetProductOptionInfoResponseVo toVo() {
+        return GetProductOptionInfoResponseVo.builder()
+                .optionInfo(optionInfo)
+                .build();
+    }
+
+}

--- a/src/main/java/com/jokim/sivillage/api/basket/infrastructure/BasketRepositoryCustom.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/infrastructure/BasketRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jokim.sivillage.api.basket.infrastructure;
+
+import com.jokim.sivillage.api.basket.dto.out.ProductOptionInfoResponseDto;
+import com.jokim.sivillage.api.product.domain.ProductOption;
+
+public interface BasketRepositoryCustom {
+
+    ProductOptionInfoResponseDto getProductOptionInfo(ProductOption productOption);
+
+}

--- a/src/main/java/com/jokim/sivillage/api/basket/infrastructure/BasketRepositoryImpl.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/infrastructure/BasketRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.jokim.sivillage.api.basket.infrastructure;
+
+import com.jokim.sivillage.api.basket.dto.out.ProductOptionInfoResponseDto;
+import com.jokim.sivillage.api.product.domain.ProductOption;
+import com.jokim.sivillage.api.product.domain.option.QColor;
+import com.jokim.sivillage.api.product.domain.option.QSize;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class BasketRepositoryImpl implements BasketRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QSize size = QSize.size;
+    private final QColor color = QColor.color;
+
+    @Override
+    public ProductOptionInfoResponseDto getProductOptionInfo(ProductOption productOption) {
+
+        String colorValue = productOption.getColor() != null ? jpaQueryFactory.select(color.value)
+                    .from(color)
+                    .where(color.eq(productOption.getColor()))
+                    .fetchOne() : "";
+
+        String sizeValue = productOption.getSize() != null ? jpaQueryFactory.select(size.value)
+                .from(size)
+                .where(size.eq(productOption.getSize()))
+                .fetchOne() : "";
+
+        return ProductOptionInfoResponseDto.toDto(
+                !colorValue.isEmpty() && !sizeValue.isEmpty() ?
+                        colorValue + "/" + sizeValue : colorValue + sizeValue);
+    }
+
+}

--- a/src/main/java/com/jokim/sivillage/api/basket/presentation/BasketController.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/presentation/BasketController.java
@@ -10,10 +10,11 @@ import com.jokim.sivillage.api.basket.dto.out.AllBasketItemsResponseDto;
 import com.jokim.sivillage.api.basket.vo.in.AddToBasketRequestVo;
 import com.jokim.sivillage.api.basket.vo.in.DeleteBasketItemsRequestVo;
 import com.jokim.sivillage.api.basket.vo.in.UpdateBasketItemCheckRequestVo;
-import com.jokim.sivillage.api.basket.vo.in.UpdateBasketItemCountRequestVo;
+import com.jokim.sivillage.api.basket.vo.in.UpdateBasketItemQuantityRequestVo;
 import com.jokim.sivillage.api.basket.vo.out.GetAllBasketItemsResponseVo;
 import com.jokim.sivillage.api.basket.vo.out.GetBasketItemCountResponseVo;
 import com.jokim.sivillage.api.basket.vo.out.GetExistsInBasketResponseVo;
+import com.jokim.sivillage.api.basket.vo.out.GetProductOptionInfoResponseVo;
 import com.jokim.sivillage.common.entity.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -58,6 +59,14 @@ public class BasketController {
             authorizationHeader)).toVo());
     }
 
+    @Operation(summary = "상품 옵션 Info 조회 API")
+    @GetMapping("/option-info/{productOptionCode}")
+    public BaseResponse<GetProductOptionInfoResponseVo> getProductOptionInfo(
+            @PathVariable String productOptionCode) {
+
+        return new BaseResponse<>(basketService.getProductOptionInfo(productOptionCode).toVo());
+    }
+
     @Operation(summary = "상품의 장바구니 존재 여부 조회 API")
     @GetMapping("/{productOptionCode}")
     public BaseResponse<GetExistsInBasketResponseVo> existsInBasket(
@@ -70,12 +79,12 @@ public class BasketController {
 
     @Operation(summary = "장바구니 상품 수량 변경 API")
     @PutMapping("/quantity")
-    public BaseResponse<Void> updateBasketItemCount(
+    public BaseResponse<Void> updateBasketItemQuantity(
             @RequestHeader("Authorization") String authorizationHeader,
-            @RequestBody UpdateBasketItemCountRequestVo updateBasketItemCountRequestVo) {
+            @RequestBody UpdateBasketItemQuantityRequestVo updateBasketItemQuantityRequestVo) {
 
-        basketService.updateBasketItemCount(UpdateBasketRequestDto.toDto(
-                extractToken(authorizationHeader), updateBasketItemCountRequestVo));
+        basketService.updateBasketItemQuantity(UpdateBasketRequestDto.toDto(
+                extractToken(authorizationHeader), updateBasketItemQuantityRequestVo));
         return new BaseResponse<>();
     }
 

--- a/src/main/java/com/jokim/sivillage/api/basket/vo/in/UpdateBasketItemQuantityRequestVo.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/vo/in/UpdateBasketItemQuantityRequestVo.java
@@ -3,7 +3,7 @@ package com.jokim.sivillage.api.basket.vo.in;
 import lombok.Getter;
 
 @Getter
-public class UpdateBasketItemCountRequestVo {
+public class UpdateBasketItemQuantityRequestVo {
 
     private String basketCode;
     private Short quantity;

--- a/src/main/java/com/jokim/sivillage/api/basket/vo/out/GetProductOptionInfoResponseVo.java
+++ b/src/main/java/com/jokim/sivillage/api/basket/vo/out/GetProductOptionInfoResponseVo.java
@@ -1,0 +1,12 @@
+package com.jokim.sivillage.api.basket.vo.out;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetProductOptionInfoResponseVo {
+
+    private String optionInfo;
+
+}

--- a/src/main/java/com/jokim/sivillage/api/product/domain/ProductOption.java
+++ b/src/main/java/com/jokim/sivillage/api/product/domain/ProductOption.java
@@ -4,8 +4,10 @@ import com.jokim.sivillage.api.product.domain.option.Color;
 import com.jokim.sivillage.api.product.domain.option.Size;
 import com.jokim.sivillage.api.product.domain.option.Etc;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class ProductOption {
 
     @Id

--- a/src/main/java/com/jokim/sivillage/api/product/infrastructure/ProductOptionRepository.java
+++ b/src/main/java/com/jokim/sivillage/api/product/infrastructure/ProductOptionRepository.java
@@ -1,0 +1,12 @@
+package com.jokim.sivillage.api.product.infrastructure;
+
+import com.jokim.sivillage.api.product.domain.ProductOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
+
+    Optional<ProductOption> findByProductOptionCode(String productOptionCode);
+
+}

--- a/src/main/java/com/jokim/sivillage/common/entity/BaseResponseStatus.java
+++ b/src/main/java/com/jokim/sivillage/common/entity/BaseResponseStatus.java
@@ -67,6 +67,7 @@ public enum BaseResponseStatus {
     NOT_EXIST_BASKET_ITEM(HttpStatus.NOT_FOUND, false, 2301, "존재하지 않는 장바구니 품목입니다."),
     INVALID_PRODUCT_QUANTITY(HttpStatus.BAD_REQUEST, false, 2303, "상품 수량이 유효하지 않습니다."),
     FAILED_TO_GENERATE_BASKET_CODE(HttpStatus.BAD_REQUEST, false, 2304, "고유한 장바구니 코드를 생성하는 데 실패했습니다."),
+    NOT_EXIST_PRODUCT_OPTION(HttpStatus.NOT_FOUND, false, 2305, "상품 옵션 코드를 다시 확인해주세요."),
 
     // Category
     NOT_EXIST_CATEGORY(HttpStatus.NOT_FOUND, false, 2401, "존재하지 않는 카테고리입니다."),


### PR DESCRIPTION
## 📣 Release: 장바구니 페이지에서의 상품 옵션 Info 조회 API 구현
### 📅 2024.09.29

### 🌵 Branch
( develop ) → ( release )

### 📢 Description
장바구니 페이지에서의 상품 옵션 Summary 조회 API 구현
이하 Pull Request 및 Issue 내용 참고

### 📦 Pull Request Number
--　--　--　--　--　--　--　--　--　--　--　--　🚑️

### 💬 Issue Number
[ #85 ] - 장바구니 페이지에서의 상품 옵션 Info 조회 API 구현

### 🔖 Note
질의 사항 있으시면 코멘트 부탁드립니다.

- **{colorName}/{sizeName}** 형식으로 데이터 반환
ex) "빨강/50", "파랑/XL",""

- 옵션 데이터가 한 개거나 없을 때
ex) "빨강",  "100",  ""